### PR TITLE
fix 'not enough arguments in call to searcher.IndexDocument'

### DIFF
--- a/examples/codelab/search_server.go
+++ b/examples/codelab/search_server.go
@@ -73,7 +73,7 @@ func indexWeibo() {
 				Timestamp:    weibo.Timestamp,
 				RepostsCount: weibo.RepostsCount,
 			},
-		})
+		},false)
 	}
 
 	searcher.FlushIndex()


### PR DESCRIPTION
not enough arguments in call to searcher.IndexDocument