### PR TITLE
error fixing & 	add fields to ScoredDocument for SearchResponse

### DIFF
--- a/core/ranker.go
+++ b/core/ranker.go
@@ -1,11 +1,12 @@
 package core
 
 import (
-	"github.com/huichen/wukong/types"
-	"github.com/huichen/wukong/utils"
 	"log"
 	"sort"
 	"sync"
+
+	"github.com/huichen/wukong/types"
+	"github.com/huichen/wukong/utils"
 )
 
 type Ranker struct {
@@ -75,7 +76,8 @@ func (ranker *Ranker) Rank(
 						DocId:                 d.DocId,
 						Scores:                scores,
 						TokenSnippetLocations: d.TokenSnippetLocations,
-						TokenLocations:        d.TokenLocations})
+						TokenLocations:        d.TokenLocations,
+						Fields:                fs})
 				}
 				numDocs++
 			}

--- a/examples/codelab/search_server.go
+++ b/examples/codelab/search_server.go
@@ -6,8 +6,6 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"flag"
-	"github.com/huichen/wukong/engine"
-	"github.com/huichen/wukong/types"
 	"io"
 	"log"
 	"net/http"
@@ -16,6 +14,9 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/huichen/wukong/engine"
+	"github.com/huichen/wukong/types"
 )
 
 const (
@@ -24,12 +25,12 @@ const (
 )
 
 var (
-	searcher = engine.Engine{}
-	wbs      = map[uint64]Weibo{}
-	weiboData = flag.String("weibo_data", "../../testdata/weibo_data.txt", "微博数据文件")
-	dictFile = flag.String("dict_file", "../../data/dictionary.txt", "词典文件")
+	searcher      = engine.Engine{}
+	wbs           = map[uint64]Weibo{}
+	weiboData     = flag.String("weibo_data", "../../testdata/weibo_data.txt", "微博数据文件")
+	dictFile      = flag.String("dict_file", "../../data/dictionary.txt", "词典文件")
 	stopTokenFile = flag.String("stop_token_file", "../../data/stop_tokens.txt", "停用词文件")
-	staticFolder = flag.String("static_folder", "static", "静态文件目录")
+	staticFolder  = flag.String("static_folder", "static", "静态文件目录")
 )
 
 type Weibo struct {
@@ -73,7 +74,7 @@ func indexWeibo() {
 				Timestamp:    weibo.Timestamp,
 				RepostsCount: weibo.RepostsCount,
 			},
-		})
+		}, false)
 	}
 
 	searcher.FlushIndex()

--- a/examples/custom_scoring_criteria.go
+++ b/examples/custom_scoring_criteria.go
@@ -17,13 +17,14 @@ import (
 	"encoding/gob"
 	"flag"
 	"fmt"
-	"github.com/huichen/wukong/engine"
-	"github.com/huichen/wukong/types"
 	"log"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/huichen/wukong/engine"
+	"github.com/huichen/wukong/types"
 )
 
 const (
@@ -142,7 +143,8 @@ func main() {
 	log.Print("建立索引")
 	for i, text := range lines {
 		searcher.IndexDocument(uint64(i),
-			types.DocumentIndexData{Content: text, Fields: fieldsSlice[i]})
+			types.DocumentIndexData{Content: text, Fields: fieldsSlice[i]},
+			false)
 	}
 	searcher.FlushIndex()
 	log.Print("索引建立完毕")

--- a/types/search_response.go
+++ b/types/search_response.go
@@ -32,6 +32,8 @@ type ScoredDocument struct {
 	// 关键词出现的位置
 	// 只有当IndexType == LocationsIndex时不为空
 	TokenLocations [][]int
+
+	Fields interface{}
 }
 
 // 为了方便排序


### PR DESCRIPTION
1. fix error: not enough arguments in call to searcher.IndexDocument
2.  add fields to ScoredDocument for SearchResponse
usage:
	i := 0
	for _, hit := range result.Docs {
		log.Println("id, score: ", hit.DocId, hit.Scores)
		var article Article
		json.Unmarshal(hit.Fields.([]byte), &article)
		log.Println("fileds: ", article)
		i++
	}