### PR TITLE
fix bug, lose forceUpdate 

### DIFF
--- a/examples/codelab/search_server.go
+++ b/examples/codelab/search_server.go
@@ -73,7 +73,7 @@ func indexWeibo() {
 				Timestamp:    weibo.Timestamp,
 				RepostsCount: weibo.RepostsCount,
 			},
-		})
+		}, false)
 	}
 
 	searcher.FlushIndex()


### PR DESCRIPTION
./search_server.go:76: not enough arguments in call to searcher.IndexDocument

func (engine *Engine) IndexDocument(docId uint64, data types.DocumentIndexData, forceUpdate bool)